### PR TITLE
Write Scalar attribute

### DIFF
--- a/api/rc3.py
+++ b/api/rc3.py
@@ -260,7 +260,7 @@ async def attribute_value(rq, host, port, domain, family, member, attr, from_alt
             
 
 	if rq.method == "PUT":
-	    text = rq.args["v"] if "v" in rq.args else rq.body
+	    text = rq.args["v"][0] if "v" in rq.args else rq.body
 	    # TODO: This is inefficient to check the type before to call
 	    # the write the attribute.
 	    if "AttributeProxy" in features:

--- a/api/rc3.py
+++ b/api/rc3.py
@@ -4,12 +4,13 @@ from time import time
 from sanic import Blueprint
 from sanic.response import json
 
-from tango import Database, CmdArgType, DevFailed, ArgType
+from tango import Database, CmdArgType, DevFailed, ArgType, AttrDataFormat
 
 import conf
 from utils import buildurl
-from cache import getDeviceProxy, getAttributeProxy
+from cache import getDeviceProxy, getAttributeProxy, getAttributeConfig, convertAttributeValue, getDeviceAttributeConfig
 from exceptions import HTTP501_NotImplemented
+from features import features
 
 
 api_rc3 = Blueprint("rc3")
@@ -250,23 +251,59 @@ async def attribute(rq, host, port, domain, family, member, attr):
 )
 async def attribute_value(rq, host, port, domain, family, member, attr, from_alt=False):
 	""" Get attribute value """
-	if rq.method == "PUT":
-		raise HTTP501_NotImplemented
-	device = "/".join((domain, family, member))
-	proxy = await getDeviceProxy(device)
-	attr_value = await proxy.read_attribute(attr)
-
-	if attr_value.type in (CmdArgType.DevState,):
-		value = str(attr_value.value)
+	if "AttributeProxy" in features:
+	    attribute = "/".join((domain, family, member, attr))
+	    aproxy = await getAttributeProxy(attribute)
 	else:
-		value = attr_value.value
+	    device = "/".join((domain, family, member))
+	    dproxy = await getDeviceProxy(device)
+            
 
-	data = {
-		"name": attr_value.name,
-		"value": value,
-		"quality": str(attr_value.quality),
-		"timestamp": attr_value.time.tv_sec
-	}
+	if rq.method == "PUT":
+	    text = rq.args["v"] if "v" in rq.args else rq.body
+	    # TODO: This is inefficient to check the type before to call
+	    # the write the attribute.
+	    if "AttributeProxy" in features:
+	        config = await getAttributeConfig(aproxy)
+	    else:
+	        config = await getDeviceAttributeConfig(dproxy, attr)
+
+            # The text is converted in the right format
+	    if config.data_format == AttrDataFormat.SCALAR:
+	        value = convertAttributeValue(config, text)
+	    else:
+	        raise HTTP501_NotImplemented
+
+
+	    if "AttributeProxy" in features:
+	        output = await aproxy.write(value)
+	    else:
+	        print(type(value))
+	        output = await dproxy.write_attribute(attr, value)
+
+            #Process the response if sync mode
+	    if "async" in rq.args and rq.args["async"]:
+	        data = None
+	    else:
+	        raise HTTP501_NotImplemented
+
+	else:
+	    if "AttributeProxy" in features:
+	        attr_value = await aproxy.read()
+	    else:
+	        attr_value = await dproxy.read_attribute(attr)
+
+	    if attr_value.type in (CmdArgType.DevState,):
+	        value = str(attr_value.value)
+	    else:
+	        value = attr_value.value
+
+	    data = {
+	    	"name": attr_value.name,
+	    	"value": value,
+	    	"quality": str(attr_value.quality),
+	    	"timestamp": attr_value.time.tv_sec
+	    }
 
 	return data if from_alt else json(data)
 

--- a/cache.py
+++ b/cache.py
@@ -1,4 +1,5 @@
 from tango.asyncio import DeviceProxy, AttributeProxy
+from tango import CmdArgType
 
 from conf import cache_size
 from async_lru import async_lru
@@ -14,3 +15,23 @@ async def getDeviceProxy(device):
 async def getAttributeProxy(attr):
 	""" Get or create AttributeProxy """
 	return await AttributeProxy(attr)
+
+@async_lru(maxsize=cache_size)
+async def getDeviceAttributeConfig(device_proxy, attribute):
+	""" Get or create AttributeProxy """
+	return device_proxy.get_attribute_config(attribute)
+
+@async_lru(maxsize=cache_size)
+async def getAttributeConfig(attribute_proxy):
+	""" Get or create AttributeProxy """
+	return await attribute_proxy.get_config()
+
+def convertAttributeValue(config, text):
+    """ Convert a text to the correct type"""
+    if config.data_type != CmdArgType.DevString:
+        #try:
+            return float(text)
+        #except ValueError:
+        #    return text
+    else:
+        return text

--- a/features.py
+++ b/features.py
@@ -1,0 +1,3 @@
+features=[
+    #AttributeProxy
+]

--- a/tests/test_rc3.py
+++ b/tests/test_rc3.py
@@ -88,6 +88,7 @@ def test_alt_attribute_value():
 		assert "timestamp" in attr
 
 
+
 def test_alt_attribute_value_multi():
 	rq, rsp = app.test_client.get("%s/rc3/hosts/%s/%s/devices/sys/tg_test/1/attributes/value?attr=double_scalar&attr=long_scalar" % urltuple)
 	b = mtango_list(rsp)
@@ -186,6 +187,9 @@ def test_attribute_value():
 	assert "quality" in b
 	assert "timestamp" in b
 
+def test_write_scalar_attribute():
+	rq, rsp = app.test_client.put("%s/rc3/hosts/%s/%s/devices/sys/tg_test/1/attributes/double_scalar/value?async=true" % urltuple, data="3.14")
+	mtango_async(rsp)
 
 def test_attribute_info():
 	rq, rsp = app.test_client.get("%s/rc3/hosts/%s/%s/devices/sys/tg_test/1/attributes/double_scalar/info" % urltuple)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -50,3 +50,7 @@ def mtango_object(rsp):
 def mtango_empty(rsp):
 	assert status(rsp, 204)
 	assert xmtango(rsp)
+
+def mtango_async(rsp):
+	assert status(rsp, 200)
+	assert xmtango(rsp)


### PR DESCRIPTION
Add the ability to write scalar attribute. It's first approach using device proxy.
There is a possibility to use with attribute proxy when the issue with PyTango https://github.com/tango-controls/pytango/issues/186

