### PR TITLE
check arg type before command

### DIFF
--- a/api/rc3.py
+++ b/api/rc3.py
@@ -408,15 +408,18 @@ async def command(rq, host, port, domain, family, member, cmd):
 	result = {} 
 	device = "/".join((domain, family, member))
 	proxy = await getDeviceProxy(device)
+	info = proxy.get_command_config(cmd)
 	if rq.method == "PUT":
 	    # Set None if no argument for DevVoid Argin
-	    argument = rq.body or None
+	    if str(info.in_type) == "DevVarStringArray":
+                argument = rq.body.decode().split(',')
+	    else:
+	        argument = rq.body or None
 	    output = await proxy.command_inout(cmd, argument)
 	    result = { "name": cmd }
 	    if output:
 	        result["output"] = output
 	else:
-	    info = proxy.get_command_config(cmd)
 	    result = {
 			"name": cmd,
 			"info": {


### PR DESCRIPTION
this would allow to retrieve all device names calling
```python
url = 'http://w-v-kitslab-cc-0:8000/tango/rest/rc3/hosts/w-v-kitslab-csdb-0.maxiv.lu.se/10000/devices/sys/database/2/commands/DbGetDeviceList'
res = requests.put(url, "*,*")

res.json()
{u'name': u'DbGetDeviceList',
 u'output': [u'admin/logger/w-v-kitslab-ec-0',
  u'AMILAN/TEST/FAKEDEV-01',
  u'amptekpx5/test/1',
  u'antdup/alramdevice/1',
  u'antdup/camerascreen/1',
  u'antdup/dummy/1',
  u'antdup/dummyplc/1',
  u'antdup/empty/test',
  ............
  u'dserver/Sardana/demo',
  u'dserver/Sardana/epu',
  ...]}